### PR TITLE
fix: Add missing pytest package for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "tavily-python>=0.4.0",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+]
 
 [project.optional-dependencies]
 dev = ["mypy>=1.11.1", "ruff>=0.6.1"]


### PR DESCRIPTION
When starting the project, running `make test` will fail because the pytest package is missing.

To add this package into the project, we run `uv add --dev pytest` which will add the package within the dev dependencies of **pyproject.toml**, and updates the **uv.lock** accordingly.