### PR TITLE
Bump protobuf version to avoid gen and runtime mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langchain-fireworks>=0.1.7",
     "python-dotenv>=1.0.1",
     "langchain-tavily>=0.1",
+    "protobuf>=6.3.1",
 ]
 
 


### PR DESCRIPTION
Fixes #26 

However this might be a quickfix, as I can't tell what is the underlying cause of the version mismatch. It may be due to some subdependency of this project.