### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
     - cron: "37 14 * * *" # Run at 7:37 AM Pacific Time (14:37 UTC) every day
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another scheduled run starts while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:
@@ -42,12 +45,12 @@ jobs:
           uv pip install mypy
           uv run mypy --strict src/
       - name: Check README spelling
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           ignore_words_file: .codespellignore
           path: README.md
       - name: Check code spelling
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           ignore_words_file: .codespellignore
           path: src/


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `integration-tests.yml` and `unit-tests.yml` (Rule 1 compliance)
- SHA-pin `codespell-project/actions-codespell@v2` → `406322ec52dd7b488e48c1c4b82e2a8b3a1bf630` in both usages in `unit-tests.yml` (Rule 6 compliance)

## Test plan

- [x] CI passes on this branch
- [x] Code scanning alerts for missing permissions are resolved after merge
