### PR TITLE
tests: skip live Anthropic integration test when API key is absent

### DIFF
--- a/tests/integration_tests/test_graph.py
+++ b/tests/integration_tests/test_graph.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from react_agent import graph
@@ -6,6 +8,10 @@ from react_agent.context import Context
 pytestmark = pytest.mark.anyio
 
 
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="requires ANTHROPIC_API_KEY for live Anthropic integration",
+)
 async def test_react_agent_simple_passthrough() -> None:
     res = await graph.ainvoke(
         {"messages": [("user", "Who is the founder of LangChain?")]},  # type: ignore


### PR DESCRIPTION
## What changed
- Added a `pytest.mark.skipif` guard to `tests/integration_tests/test_graph.py` so the live Anthropic integration test only runs when `ANTHROPIC_API_KEY` is set.
- Kept the test logic unchanged when a key is present; this only changes behavior in secretless environments.

## Why
- The integration test currently performs a live API call unconditionally.
- In environments without Anthropic credentials (new contributors, local dev shells, automation sandboxes), the suite fails with an authentication error that is unrelated to code correctness.

## Insight / Why this matters
- **Root cause:** environment-coupled integration test without a credential gate.
- **Why it is easy to miss:** maintainers and CI often have secrets configured, so this failure path is invisible to many regular runs.
- **Tradeoff:** when no key is configured, this specific live integration test is skipped instead of failing hard. This favors signal quality (real regressions vs. missing local secrets) while preserving full integration coverage when credentials are available.
- **Impact:** fewer false-negative failures and smoother contribution/testing workflow for users who run tests without Anthropic secrets.

## Practical gain / Why this matters
- Immediate developer UX and reliability gain: local/automation test runs no longer fail due to missing external secrets.
- Maintainers get cleaner test signal because failures are more likely to reflect product regressions rather than environment setup gaps.

## Testing
- `scripts/clone_and_test.sh langchain-ai/react-agent`
  - Before change: `1 failed, 3 passed` (failed in `test_react_agent_simple_passthrough` with missing Anthropic authentication).
  - After change: `3 passed, 1 skipped`.
- `pytest tests/integration_tests/test_graph.py -q`
  - After change: `1 skipped` when `ANTHROPIC_API_KEY` is unset.

## Risk analysis
- Scope is limited to a single integration test file.
- No runtime/library code path changed.
- Behavior with valid credentials remains unchanged; only secretless environments are affected.
