### PR TITLE
fix: patch 1 security alert (high severity)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ lint.ignore = [
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.uv]
+# CVE-2026-32597: pyjwt < 2.12.0 accepts unknown `crit` header extensions.
+# Transitive via langgraph-api -> pyjwt. Remove once langgraph-api requires pyjwt>=2.12.0.
+constraint-dependencies = ["pyjwt>=2.12.0"]
+
 [dependency-groups]
 dev = [
     "anyio>=4.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <4.0"
 
+[manifest]
+constraints = [{ name = "pyjwt", specifier = ">=2.12.0" }]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -2292,11 +2295,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Security Alert Patch

Resolves 1 Dependabot security alert in the high severity tier.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| PyJWT | (unconstrained, resolved 2.10.1) | `>=2.12.0` (resolved 2.12.1) | C — constraint | dev-only | CVE-2026-32597 |

Strategy C = `[tool.uv.constraint-dependencies]` override — valid because PyJWT is dev-only (transitive via `langgraph-cli[inmem]` → `langgraph-api` → `pyjwt`).

### CVE Details

- **[CVE-2026-32597](https://nvd.nist.gov/vuln/detail/CVE-2026-32597)** / [GHSA-752w-5fwx-jx9f](https://github.com/advisories/GHSA-752w-5fwx-jx9f): PyJWT accepts unknown `crit` header extensions — versions < 2.12.0 are vulnerable.

### Removal Condition

The `constraint-dependencies` entry can be removed once `langgraph-api` releases a version that requires `pyjwt>=2.12.0` upstream.

### Linear Tickets

No matching Linear tickets found for the resolved CVEs.

### Verification

- [x] Lockfile updated — resolved version is now 2.12.1
- [x] Linters pass (`ruff check`)
- [ ] Tests pass (CI)

🤖 Submitted by langster-patch