### PR TITLE
fix: add missing py.typed marker and upgrade CI actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION
## Summary

- Add missing `src/react_agent/py.typed` marker file (declared in pyproject.toml but doesn't exist, needed for PEP 561)
- Upgrade `actions/setup-python` from v4 to v5 in unit-tests.yml and integration-tests.yml
- Add `.ruff_cache/` to .gitignore (ruff is used for linting)

## Testing

Verified py.typed is declared in pyproject.toml package-data. Verified setup-python@v4 in workflow files. Verified .ruff_cache not in .gitignore.