### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: "increase"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root uv dependency set
- add weekly Dependabot updates for GitHub Actions
- preserve declared Python dependency bounds with `versioning-strategy: increase`

## Validation

- [x] Parsed `.github/dependabot.yml` with Ruby YAML
- [x] Ran `git diff --check`
- [x] Confirmed the PR only adds `.github/dependabot.yml`